### PR TITLE
A better revised version for M2N2

### DIFF
--- a/TSB_AD/model_wrapper.py
+++ b/TSB_AD/model_wrapper.py
@@ -384,9 +384,23 @@ def run_MOMENT_FT(data_train, data_test, win_size=256):
     score = clf.decision_function(data_test)
     return score.ravel()
 
-def run_M2N2(data_train, data_test, epochs=10, win_size=12, lr=1e-3, batch_size=128):
+def run_M2N2(
+        data_train, data_test, win_size=12, stride=12,
+        batch_size=64, epochs=100, latent_dim=16,
+        lr=1e-3, ttlr=1e-3, normalization='Detrend',
+        gamma=0.99, th=0.9, valid_size=0.2, infer_mode='online'
+    ):
     from .models.M2N2 import M2N2
-    clf = M2N2(win_size=win_size, num_channels=data_test.shape[1], lr=lr, batch_size=batch_size, epochs=epochs)
+    clf = M2N2(
+        win_size=win_size, stride=stride,
+        num_channels=data_test.shape[1],
+        batch_size=batch_size, epochs=epochs,
+        latent_dim=latent_dim,
+        lr=lr, ttlr=ttlr,
+        normalization=normalization,
+        gamma=gamma, th=th, valid_size=valid_size,
+        infer_mode=infer_mode
+    )
     clf.fit(data_train)
     score = clf.decision_function(data_test)
     return score.ravel()


### PR DESCRIPTION
I have made some changes based on the original M2N2 code, as follows:

- ​​remove​ unused code in M2N2.py for better readability.

- modify the code to align with the original paper and official implementation, including:
    - M2N2 generates anomaly scores for each timestep in a window, whereas the previous implementation used only the score at the last timestep per window, that is inconsistent to the official settings.
    - The previous version allocated a validation set but omitted the validation process (likely an oversight). Now, I have added corresponding code to support both validation-enabled and validation-free setting.
    - The original testing setup used a stride of 1 and averaged overlapping-window regions to match anomaly score length with the input sequence. While this post-processing improved metric results (significantly), it violated online inference constraints by utilizing future data. To strictly follow the original paper's methodology, I implement a right-side-padding for anomaly scores, although this differs from the authors' approach of applying padding directly to the input sequences.
    - add an `infer_mode` option to support both offline and online inference modes.

- refactor the `run_M2N2` function to support richer parameter configurations, and give more reasonable parameters, especially the latent dimension must be smaller than the input one to enforce the bottleneck structure in the encoder-decoder architecture, as this compression mechanism is essential for anomaly detection.
