### PR TITLE
Fix FFT taking the Fourier transform along the wrong axis

### DIFF
--- a/TSB_AD/models/FFT.py
+++ b/TSB_AD/models/FFT.py
@@ -56,16 +56,29 @@ class FFT(BaseDetector):
     @staticmethod
     def reduce_parameters(f: np.ndarray, k: int) -> np.ndarray:
         transformed = f.copy()
-        transformed[k:] = 0
+        if k == 1:
+            transformed[1:] = 0
+        else:
+            # keep the k lowest frequencies together with their negative-frequency
+            # conjugates, so the inverse transform stays real and the retained
+            # components keep their amplitude
+            transformed[k:-(k - 1)] = 0
         return transformed
 
     def calculate_local_outliers(self):
-        n = len(self.data)
+        data = np.asarray(self.data)
+        if data.ndim > 1:
+            if data.shape[1] != 1:
+                raise ValueError(
+                    "FFT expects a univariate series, got %d channels" % data.shape[1])
+            data = data[:, 0]
+
+        n = len(data)
         k = max(min(self.ifft_parameters, n), 1)
-        y = self.reduce_parameters(np.fft.fft(self.data), k)
+        y = self.reduce_parameters(np.fft.fft(data), k)
         f2 = np.real(np.fft.ifft(y))
 
-        so = np.abs(f2 - self.data)
+        so = np.abs(f2 - data)
         mso = np.mean(so)
         neighbor_c = self.local_neighbor_window // 2
 
@@ -73,8 +86,8 @@ class FFT(BaseDetector):
         score_idxs = []
         for i in range(n):
             if so[i] > mso:
-                nav = np.mean(self.data[max(i - neighbor_c, 0):min(i + neighbor_c + 1, n)])
-                scores.append(self.data[i] - nav)
+                nav = np.mean(data[max(i - neighbor_c, 0):min(i + neighbor_c + 1, n)])
+                scores.append(data[i] - nav)
                 score_idxs.append(i)
 
         if not scores:

--- a/tests/test_fft_model.py
+++ b/tests/test_fft_model.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from TSB_AD.models.FFT import FFT
+
+
+def _series(n=1000, period=50, spike_at=400, seed=0):
+    rng = np.random.default_rng(seed)
+    t = np.arange(n)
+    x = np.sin(2 * np.pi * t / period) + 0.05 * rng.standard_normal(n)
+    x[spike_at] += 8.0
+    return x.reshape(-1, 1)
+
+
+def test_reduce_parameters_keeps_conjugate_pairs():
+    # Truncating a real signal's spectrum must keep the negative-frequency
+    # conjugates, otherwise the inverse transform is not real and the retained
+    # oscillating components come back at half amplitude.
+    x = _series().ravel()
+    k = 5
+    y = FFT.reduce_parameters(np.fft.fft(x), k)
+    assert np.count_nonzero(y) == 2 * k - 1
+    assert np.allclose(np.fft.ifft(y).imag, 0.0, atol=1e-9)
+
+
+def test_scores_are_invariant_to_a_constant_offset():
+    # The zero-frequency term is always retained, so it absorbs a constant
+    # offset exactly: the fitted curve shifts by the same constant, the residual
+    # is unchanged, and the neighbour deviations data[i] - mean(neighbours) are
+    # unchanged. Scores must therefore not depend on the offset.
+    x = _series()
+    a = FFT(normalize=False).fit(x).decision_scores_
+    b = FFT(normalize=False).fit(x + 100.0).decision_scores_
+    np.testing.assert_allclose(np.ravel(a), np.ravel(b), rtol=1e-8, atol=1e-8)
+
+
+def test_multivariate_input_is_rejected_explicitly():
+    x = _series()
+    xm = np.column_stack([x.ravel(), np.roll(x.ravel(), 7)])
+    with pytest.raises(ValueError, match="univariate"):
+        FFT(normalize=False).fit(xm)


### PR DESCRIPTION
---

`TSB_AD/models/FFT.py` passes the `(n_samples, n_features)` matrix straight to `np.fft.fft`,
which transforms the last axis. For univariate input that axis has length 1, so the transform is
the identity, and `reduce_parameters`' `transformed[k:] = 0` then zeroes the *time* axis instead
of the frequency axis. The IFFT fitted curve ends up being the series truncated to its first `k`
samples, and `so = |f2 - data|` is the raw magnitude of the series rather than a reconstruction
residual, so no frequency analysis happens.

On `e0975a5`, numpy 1.26.4:

```python
import numpy as np
from TSB_AD.models.FFT import FFT

rng = np.random.default_rng(0)
x = np.sin(2 * np.pi * np.arange(1000) / 50) + 0.05 * rng.standard_normal(1000)
x[400] += 8.0
d = FFT(ifft_parameters=5, normalize=False).fit(x.reshape(-1, 1)).data

print(np.fft.fft(d).shape[-1])                        # 1, i.e. n_features
print(np.allclose(np.fft.fft(d), d.astype(complex)))  # True, the transform is the identity

f2 = np.real(np.fft.ifft(FFT.reduce_parameters(np.fft.fft(d), 5)))
print(np.allclose(f2[:5], d[:5]), np.all(f2[5:] == 0))   # True True
```

Expected: `f2` is a 5-term Fourier series of the input. Actual: `f2` is the input with everything
from index 5 onward zeroed.

`reduce_parameters` has a second problem, independent of the axis: it keeps the `k` lowest bins
and drops their negative-frequency conjugates. The TimeEval implementation this file is adapted
from uses `transformed[k:-(k - 1)] = 0` with a `k == 1` special case, and documents its input as
1-dimensional. One-sided truncation makes the inverse transform complex (`max |imag| = 0.0292` on
the series above) and halves the amplitude of the retained oscillating components while passing
the zero-frequency term through unchanged (`np.ptp` ratio 0.5000 at `k = 5`).

Changes:

* flatten to the single channel before the transform, and raise `ValueError` for genuinely
  multivariate input, that previously reached `if so[i] > mso` and failed with
  `The truth value of an array with more than one element is ambiguous`. The guard follows
  `_as_univariate` in `TSB_AD/models/HSF_AD.py`.
* restore the symmetric truncation in `reduce_parameters`.
* add `tests/test_fft_model.py`.

The repository has no test suite at `e0975a5` (`git ls-tree -r --name-only e0975a5` contains no
`test_*.py`, `*_test.py`, `conftest.py`, `pytest.ini` or `tox.ini`, and no `.github/workflows`),
so there is no baseline suite to compare against. The three new tests cover the conjugate-pair
truncation, invariance to a constant offset, and the multivariate guard; all three fail on the
unmodified tree and pass with the patch.

One interaction worth flagging before you evaluate this. Once the residual is accurate, a single
isolated point anomaly produces exactly one local outlier, and `calculate_region_outliers` only
forms a region from two or more, so the series scores zero everywhere. On a noise-free bin-3 sine
of length 512 with a `+5.0` spike at index 300 and `ifft_parameters=5`, the current code reports
21 local outliers spread over indices 290..310 and scores 21 points; with this patch it reports
one local outlier, at index 300, and scores none. The spike is scored again once the noise level
reaches 0.02, and a 10-point sequence anomaly is scored at every noise level I tried. That region
rule is pre-existing and this PR does not touch it, happy to extend it to score a lone outlier
here instead, if you would rather that landed in one go.

Scores from this version are not comparable with scores from the previous one. FFT is not in
`benchmark_exp/benchmark_eval_results/` or `benchmark_exp/leaderboard_results/`, so nothing in the
repository needs updating; if you hold results for it elsewhere I am happy to rerun TSB-AD-U
rather than leave them inconsistent. Happy to split the truncation change into its own PR, or to
adjust anything else here.
