### PR TITLE
Fix wrong-domain edge padding in the SR log-amplitude spectrum

### DIFF
--- a/TSB_AD/models/SR.py
+++ b/TSB_AD/models/SR.py
@@ -18,7 +18,7 @@ def SR(X, window_size):
     window_amp = 100
 
     pad_left = (window_amp - 1) // 2
-    padded_freq = np.concatenate([np.tile(X[0], pad_left), freq, np.tile(X[-1], window_amp - pad_left - 1)])
+    padded_freq = np.concatenate([np.tile(freq[0], pad_left), freq, np.tile(freq[-1], window_amp - pad_left - 1)])
     conv_amp = np.ones(window_amp) / window_amp
     ma_freq = np.convolve(padded_freq, conv_amp, 'valid')
     # construct moving average log amplitude spectrum

--- a/tests/test_sr_model.py
+++ b/tests/test_sr_model.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from TSB_AD.models.SR import SR
+
+
+def test_saliency_map_is_shift_equivariant():
+    # |FFT(x)| does not change when x is rolled, only the phase does, so the
+    # averaged log-amplitude spectrum and the spectral residual are unchanged and
+    # the saliency map of a rolled series is the rolled saliency map.
+    rng = np.random.default_rng(0)
+    n, shift = 512, 137
+    t = np.arange(n)
+    x = np.sin(2 * np.pi * t / 64) + 0.05 * rng.standard_normal(n)
+    x[300] += 6.0
+    x = x.reshape(-1, 1)
+
+    sr = SR(x.copy(), window_size=64)
+    sr_rolled = SR(np.roll(x, shift, axis=0).copy(), window_size=64)
+
+    np.testing.assert_allclose(sr_rolled, np.roll(sr, shift), rtol=1e-9, atol=1e-9)


### PR DESCRIPTION
The moving average over the log-amplitude spectrum in `TSB_AD/models/SR.py` is edge-padded with
`X[0]` and `X[-1]`, which at that point are samples of the min-max scaled time-domain series, not
spectrum values (lines 16-21):

```python
    # select just the first half of the sym_freq
    freq = sym_freq[:(len(sym_freq) + 1) // 2]
    window_amp = 100

    pad_left = (window_amp - 1) // 2
    padded_freq = np.concatenate([np.tile(X[0], pad_left), freq, np.tile(X[-1], window_amp - pad_left - 1)])
```

The visible symptom is that the saliency map depends on where the series happens to start.
`|FFT(x)|` is unchanged by a circular shift of `x` (only the phase moves), so the averaged
log-amplitude spectrum and the spectral residual are unchanged too, and `SR(roll(x, m))` should
equal `roll(SR(x), m)`:

```python
import numpy as np
from TSB_AD.models.SR import SR

rng = np.random.default_rng(0)
n, m = 512, 137
t = np.arange(n)
x = np.sin(2 * np.pi * t / 64) + 0.05 * rng.standard_normal(n)
x[300] += 6.0
x = x.reshape(-1, 1)

s = SR(x.copy(), window_size=64)
sm = SR(np.roll(x, m, axis=0).copy(), window_size=64)
print(np.abs(sm - np.roll(s, m)).max() / np.abs(s).max())   # 0.0101
```

Expected 0 up to floating point; actual 1.0% of the peak score. Padding with `freq[0]` /
`freq[-1]` instead brings it to `1.1e-16`.

The pad values sit in `[0, 1]` while `freq` holds log amplitudes: on the series above
`X[0] = 0.188` and `freq[0] = -0.242`, so `ma_freq[0]` picks up `49 * (X[0] - freq[0]) / 100 =
0.211`. It affects 99 bins, the first 49 and the last 50, with the offset decaying linearly to
zero away from each edge; the interior of the half-spectrum is untouched.

The error shrinks with length: on the same signal family with the spike at the midpoint the shift
error is 2.0% at `n = 256` and 0.03% at `n = 16384`, so the effect on long benchmark series is
small. The ranking does still move: on the 512-point series above, index 301 is absent from the
shipped top-10 scores and 5th with the edge-padded version, next to the spike injected at 300.
`SR` is one of the detectors in `benchmark_exp/benchmark_eval_results/uni_mergedTable_VUS-PR.csv`,
so this is an input to a published number rather than a synthetic-only example; I have not re-run
the benchmark, so I am not quoting a new figure for it.

The change is the two pad values. It also adds `tests/test_sr_model.py` with the
shift-equivariance check, there is no `tests/` directory at the moment, so this is the only test
in it; it fails on `main` and passes with the change. Happy to drop it if you would rather not
start a test directory, or to move it wherever you prefer.

Environment: numpy 1.26.4, Python 3.12.3.
